### PR TITLE
Add GPT-4 Turbo Support

### DIFF
--- a/components/Chat/ChatInputTokenCount.tsx
+++ b/components/Chat/ChatInputTokenCount.tsx
@@ -11,6 +11,7 @@ import { OpenAIModelID, OpenAIModels } from '@/types/openai';
 const PRICING: Record<string, BigNumber> = {
   'gpt-4': BigNumber('0.03').div(1000),
   'gpt-4-32k': BigNumber('0.03').div(1000),
+  'gpt-4-1106-preview': BigNumber('0.01').div(1000),
   'gpt-3.5-turbo': BigNumber('0.002').div(1000),
 };
 

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -13,6 +13,7 @@ export enum OpenAIModelID {
   GPT_3_5_AZ = 'gpt-35-turbo',
   GPT_4 = 'gpt-4',
   GPT_4_32K = 'gpt-4-32k',
+  GPT_4_TURBO = 'gpt-4-1106-preview',
 }
 
 // in case the `DEFAULT_MODEL` environment variable is not set or set to an unsupported model
@@ -45,6 +46,13 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     name: 'GPT-4-32K',
     maxLength: 96000,
     tokenLimit: 32000,
+    messageTokens: 3,
+  },
+  [OpenAIModelID.GPT_4_TURBO]: {
+    id: OpenAIModelID.GPT_4_TURBO,
+    name: 'GPT-4-Turbo',
+    maxLength: 380000,
+    tokenLimit: 128000,
     messageTokens: 3,
   },
 };


### PR DESCRIPTION
This adds support for GPT-4 Turbo. Worth noting it's in preview at the moment
and doesn't appear to be returned from the `/v1/models` request, so we have to
somewhat hack around that for now.

https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo

Note: We should probably also update the GPT-3.5 Turbo eventually, as there's a
new model name with a higher context window. By default from that announcement
it appears it'll be done automatically come December:
https://openai.com/blog/new-models-and-developer-products-announced-at-devday