### PR TITLE
Handle usage SSE event

### DIFF
--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -1,7 +1,13 @@
 import { Message } from '@/types/chat';
 import { OpenAIModel } from '@/types/openai';
 
-import { AZURE_DEPLOYMENT_ID, OPENAI_API_HOST, OPENAI_API_TYPE, OPENAI_API_VERSION, OPENAI_ORGANIZATION } from '../app/const';
+import {
+  AZURE_DEPLOYMENT_ID,
+  OPENAI_API_HOST,
+  OPENAI_API_TYPE,
+  OPENAI_API_VERSION,
+  OPENAI_ORGANIZATION,
+} from '../app/const';
 
 import {
   ParsedEvent,
@@ -30,7 +36,7 @@ export class OpenAIError extends Error {
 export const OpenAIStream = async (
   model: OpenAIModel,
   systemPrompt: string,
-  temperature : number,
+  temperature: number,
   key: string,
   messages: Message[],
 ) => {
@@ -42,18 +48,19 @@ export const OpenAIStream = async (
     headers: {
       'Content-Type': 'application/json',
       ...(OPENAI_API_TYPE === 'openai' && {
-        Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`
+        Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`,
       }),
       ...(OPENAI_API_TYPE === 'azure' && {
-        'api-key': `${key ? key : process.env.OPENAI_API_KEY}`
+        'api-key': `${key ? key : process.env.OPENAI_API_KEY}`,
       }),
-      ...((OPENAI_API_TYPE === 'openai' && OPENAI_ORGANIZATION) && {
-        'OpenAI-Organization': OPENAI_ORGANIZATION,
-      }),
+      ...(OPENAI_API_TYPE === 'openai' &&
+        OPENAI_ORGANIZATION && {
+          'OpenAI-Organization': OPENAI_ORGANIZATION,
+        }),
     },
     method: 'POST',
     body: JSON.stringify({
-      ...(OPENAI_API_TYPE === 'openai' && {model: model.id}),
+      ...(OPENAI_API_TYPE === 'openai' && { model: model.id }),
       messages: [
         {
           role: 'system',
@@ -96,11 +103,13 @@ export const OpenAIStream = async (
           if (data !== '[DONE]') {
             try {
               const json = JSON.parse(data);
-              if (json.choices[0].finish_reason != null) {
+              const choice = json.choices[0];
+              const usage = json.usage;
+              if ((choice && choice.finish_reason != null) || usage) {
                 controller.close();
                 return;
               }
-              const text = json.choices[0].delta.content;
+              const text = choice.delta.content;
               const queue = encoder.encode(text);
               controller.enqueue(queue);
             } catch (e) {


### PR DESCRIPTION
OpenAI returns a choice-less `usage` event for the dedicated instance which currently errors as the app always expects to have at least one choice. 

![image](https://github.com/Shopify/chatbot-ui/assets/8755434/d1d5af93-246e-45cf-a1a3-02d5f11dfc03)


```
...rest of stream
{
  choices: [{ index: 0, delta: { content: '!' }, finish_reason: null }],
  usage: undefined
}
{
  choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
  usage: undefined
}
{
  choices: [],
  usage: { prompt_tokens: 269, completion_tokens: 22, total_tokens: 291 }
}
```

🎩 

1. Grab a `team` token (dedicated instance isn't used for personal tokens) from https://openai-proxy.shopify.io/
2. `OPENAI_API_HOST=https://openai-proxy.shopify.ai OPENAI_API_KEY=<token from proxy> dev s`

![image](https://github.com/Shopify/chatbot-ui/assets/8755434/3264e2fc-d6f0-48a9-bac1-2177d5bcf8ee)

