### PR TITLE
Ignore usage events, cant double close the controller

### DIFF
--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -105,8 +105,11 @@ export const OpenAIStream = async (
               const json = JSON.parse(data);
               const choice = json.choices[0];
               const usage = json.usage;
-              if ((choice && choice.finish_reason != null) || usage) {
+              if (choice && choice.finish_reason != null) {
                 controller.close();
+                return;
+              } else if (usage) {
+                // Ignore usage events
                 return;
               }
               const text = choice.delta.content;


### PR DESCRIPTION
Noticed `TypeError: The stream is not in a state that permits close` in the logs. 

Happens as both the last delta + the usage try to both close. Opting to ignore the usage events for now and expecting OpenAI to always return the deltas before the final usage & `DONE` events.