### PR TITLE
Add deprecation notice to footer.

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -385,18 +385,21 @@ export const ChatInput = ({
         </div>
       </div>
       <div className="px-3 pt-2 pb-3 text-center text-[12px] text-black/50 dark:text-white/50 md:px-4 md:pt-3 md:pb-6">
-        <a
-          href="https://github.com/mckaywrigley/chatbot-ui"
+       <p className='text-black/80 dark:text-white/80'>
+          <strong>ATTN:</strong> gpt.shopify.io is being deprecated in favor of: <a href="https://chat.shopify.io"
           target="_blank"
-          rel="noreferrer"
-          className="underline"
-        >
-          ChatBot UI
-        </a>
-        .{' '}
+          className="underline font-bold tracking-wider dark:decoration-black/50 dark:decoration-white/50">
+          chat.shopify.io
+          </a>.
+        </p>
+        <p className='text-black/80 dark:text-white/80'>
+        Please use the new chat interface for future interactions.
+        </p>
+        <p>
         {t(
           "Shopify-internal information ok, no PII.",
         )}
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION

![Screenshot 2024-04-19 at 12 32 27 PM](https://github.com/Shopify/chatbot-ui/assets/2829924/175ce92a-90cf-454c-886f-3fb8eeed0b31)
![Screenshot 2024-04-19 at 12 32 18 PM](https://github.com/Shopify/chatbot-ui/assets/2829924/158d8007-8635-470c-b1a1-101b9259d53d)


## Copilot summary

This pull request includes a change to the `ChatInput` component in the `components/Chat/ChatInput.tsx` file. The change updates the information displayed to the user, indicating the deprecation of `gpt.shopify.io` in favor of `chat.shopify.io`, and instructs the user to use the new chat interface for future interactions.