### PR TITLE
Default to gpt-4-turbo for deprecated models

### DIFF
--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -100,6 +100,11 @@ const Home = ({
   // FETCH MODELS ----------------------------------------------
 
   const handleSelectConversation = (conversation: Conversation) => {
+    // Manually sets the model to GPT-4-turbo if the model is no longer available
+    if (conversation.model && OpenAIModels[conversation.model.id as OpenAIModelID] === undefined) {
+      conversation.model = OpenAIModels[OpenAIModelID.GPT_4_TURBO];
+    }
+
     dispatch({
       field: 'selectedConversation',
       value: conversation,

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -19,7 +19,7 @@ export const fallbackModelID = OpenAIModelID.GPT_3_5;
 export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   [OpenAIModelID.GPT_3_5]: {
     id: OpenAIModelID.GPT_3_5,
-    name: 'GPT-3.5',
+    name: 'GPT-3.5 Turbo',
     maxLength: 12000,
     tokenLimit: 4097,
     messageTokens: 4,


### PR DESCRIPTION
- Conversations that were started with any model outside of gpt-3.5-turbo or gpt-4-turbo will now fallback to using gpt-4-turbo.